### PR TITLE
Testing cleanup

### DIFF
--- a/contracts/platform/bondage/Bondage.sol
+++ b/contracts/platform/bondage/Bondage.sol
@@ -29,7 +29,7 @@ contract Bondage is Destructible, BondageInterface, Upgradable {
         _;
     }
 
-    /// @dev Initialize Storage, Token, anc CurrentCost Contracts
+    /// @dev Initialize Storage, Token, and CurrentCost Contracts
     constructor(address c) Upgradable(c) public {
         _updateDependencies();
     }
@@ -353,7 +353,7 @@ contract Bondage is Destructible, BondageInterface, Upgradable {
 }
 
     /*************************************** STORAGE ****************************************
-    * 'holders', holderAddress, 'initialized', oracleAddress => {uint256} 1 -> provider-subscriber initialized, 0 -> not initialized 
+    * 'holders', holderAddress, 'initialized', oracleAddress => {uint256} 1 -> provider-subscriber initialized, 0 -> not initialized
     * 'holders', holderAddress, 'bonds', oracleAddress, endpoint => {uint256} number of dots this address has bound to this endpoint
     * 'oracles', oracleAddress, endpoint, 'broker' => {address} address of endpoint broker, 0 if none
     * 'escrow', holderAddress, oracleAddress, endpoint => {uint256} amount of Zap that have been escrowed

--- a/contracts/platform/database/Database.sol
+++ b/contracts/platform/database/Database.sol
@@ -13,10 +13,6 @@ contract Database is Ownable, DatabaseInterface {
     mapping (bytes32 => address[]) data_addressArray;
     mapping (address => bool) allowed;
 
-    constructor() public {
-
-    }
-
     modifier storageOnly {
         require(allowed[msg.sender], "Error: Access not allowed to storage");
         _;

--- a/contracts/platform/registry/Registry.sol
+++ b/contracts/platform/registry/Registry.sol
@@ -117,14 +117,12 @@ contract Registry is Destructible, RegistryInterface, Upgradable {
 
     //Set title for registered provider account
     function setProviderTitle(bytes32 title) public {
-
         require(isProviderInitiated(msg.sender), "Error: Provider is not initiated");
         db.setBytes32(keccak256(abi.encodePacked('oracles', msg.sender, "title")), title);
     }
 
     //Clear an endpoint with no bonds
     function clearEndpoint(bytes32 endpoint) public {
-
         require(isProviderInitiated(msg.sender), "Error: Provider is not initiated");
 
         uint256 bound = db.getNumber(keccak256(abi.encodePacked('totalBound', msg.sender, endpoint)));
@@ -135,7 +133,7 @@ contract Registry is Destructible, RegistryInterface, Upgradable {
         for(uint256 i = 0; i < endpoints.length; i++) {
             if( endpoints[i] == endpoint ) {
                db.setBytesArrayIndex(keccak256(abi.encodePacked("oracles", msg.sender, "endpoints")), i, bytes32(0));
-               break; 
+               break;
             }
         }
         db.pushBytesArray(keccak256(abi.encodePacked('oracles', msg.sender, 'endpoints')), bytes32(0));

--- a/contracts/token/Faucet.sol
+++ b/contracts/token/Faucet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.24;
 
 contract Token {
     function transfer(address to, uint256 amount) public returns (bool);
@@ -19,7 +19,7 @@ contract Faucet {
     }
 
     constructor(address _token) public {
-        owner=msg.sender;
+        owner = msg.sender;
         token = Token(_token);
     }
 

--- a/contracts/token/ZapToken.sol
+++ b/contracts/token/ZapToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.24;
 
 library SafeMath {
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {

--- a/test/0_coordinator_test.js
+++ b/test/0_coordinator_test.js
@@ -2,10 +2,10 @@ import EVMRevert from './helpers/EVMRevert';
 
 const BigNumber = web3.BigNumber;
 
-const expect = require('chai')
-    .use(require('chai-as-promised'))
-    .use(require('chai-bignumber')(BigNumber))
-    .expect;
+const should = require('chai')
+          .use(require('chai-as-promised'))
+          .use(require('chai-bignumber')(web3.BigNumber))
+          .should();
 
 const ZapCoordinator = artifacts.require("ZapCoordinator");
 const Database = artifacts.require("Database");
@@ -14,7 +14,6 @@ const CurrentCost = artifacts.require("CurrentCost");
 
 const Utils = require("./helpers/utils.js");
 
-
 contract('ZapCoordinator', async (accounts) => {
     const owner = accounts[0];
 
@@ -22,8 +21,8 @@ contract('ZapCoordinator', async (accounts) => {
         // Deploy initial contracts
         this.currentTest.coord = await ZapCoordinator.new();
         this.currentTest.db = await Database.new();
-        await this.currentTest.db.transferOwnership(this.currentTest.coord.address);
-        await this.currentTest.coord.addImmutableContract('DATABASE', this.currentTest.db.address);
+        await this.currentTest.db.transferOwnership(this.currentTest.coord.address).should.be.fulfilled;
+        await this.currentTest.coord.addImmutableContract('DATABASE', this.currentTest.db.address).should.be.fulfilled;
     });
 
     it("COORDINATOR_1 - addImmutableContract() - Check that we can set the DATABASE to provider", async function () {
@@ -31,57 +30,61 @@ contract('ZapCoordinator', async (accounts) => {
     });
 
     it("COORDINATOR_2 - addImmutableContract() - Check that we can't set the DATABASE to provider with the wrong owner", async function () {
-        await expect(this.test.coord.addImmutableContract('DATABASE', this.test.db.address, { from: accounts[1] })).to.eventually.be.rejectedWith(EVMRevert);
+        await this.test.coord.addImmutableContract('DATABASE', this.test.db.address, { from: accounts[1] }).should.be.rejectedWith(EVMRevert);
     });
 
     it("COORDINATOR_3 - addImmutableContract() - Check that we can't set the DATABASE to a null address", async function () {
-        await expect(this.test.coord.addImmutableContract('DATABASE', 0x0, { from: accounts[1] })).to.eventually.be.rejectedWith(EVMRevert);
+        await this.test.coord.addImmutableContract('DATABASE', 0x0, { from: accounts[1] }).should.be.rejectedWith(EVMRevert);
     });
 
     it("COORDINATOR_4 - addImmutableContract() - Check that when we set the DATABASE it updates db", async function () {
-        await expect(await this.test.coord.db()).equals(this.test.db.address);
+        let addr = await this.test.coord.db()
+        addr.should.equal(this.test.db.address);
     });
 
     it("COORDINATOR_5 - getContract() - Check that we can get the DATABASE address after setting it", async function () {
-        await expect(await this.test.coord.getContract.call('DATABASE')).equals(this.test.db.address);
+        let addr = await this.test.coord.getContract.call('DATABASE');
+        addr.should.equal(this.test.db.address);
     });
 
     it("COORDINATOR_6 - getContractName() - Check that DATABASE doesn't add to loadedContracts", async function () {
-        await expect(this.test.coord.getContractName.call(0)).to.eventually.be.rejectedWith('invalid opcode');
+        await this.test.coord.getContractName.call(0).should.be.rejectedWith('invalid opcode');
     });
 
     it("COORDINATOR_7 - updateContract() - Check that we can update REGISTRY", async function () {
         const reg = await Registry.new(this.test.coord.address);
-        await this.test.coord.updateContract('REGISTRY', reg.address);
+        await this.test.coord.updateContract('REGISTRY', reg.address).should.be.fulfilled;
     });
 
     it("COORDINATOR_8 - updateContract() - Check that we can't update REGISTRY from an address that's not the owner", async function () {
         const reg = await Registry.new(this.test.coord.address);
-        await expect(this.test.coord.updateContract('REGISTRY', reg.address, { from: accounts[1] })).to.eventually.be.rejectedWith(EVMRevert);
+        await this.test.coord.updateContract('REGISTRY', reg.address, { from: accounts[1] }).should.be.rejectedWith(EVMRevert);
     });
 
     it("COORDINATOR_9 - updateContract() - Check that we can update REGISTRY twice", async function () {
         const reg = await Registry.new(this.test.coord.address);
         const reg2 = await Registry.new(this.test.coord.address);
 
-        await this.test.coord.updateContract('REGISTRY', reg.address);
-        await this.test.coord.updateContract('REGISTRY', reg2.address);
+        await this.test.coord.updateContract('REGISTRY', reg.address).should.be.fulfilled;
+        await this.test.coord.updateContract('REGISTRY', reg2.address).should.be.fulfilled;
     });
 
     it("COORDINATOR_10 - getContract() - Check that we get the REGISTRY address after updateContract", async function () {
         const reg = await Registry.new(this.test.coord.address);
 
-        await this.test.coord.updateContract('REGISTRY', reg.address);
-        await expect(await this.test.coord.getContract.call('REGISTRY')).equals(reg.address);
+        await this.test.coord.updateContract('REGISTRY', reg.address).should.be.fulfilled;
+        let addr = await this.test.coord.getContract.call('REGISTRY').should.be.fulfilled;
+        addr.should.equal(reg.address);
     });
 
     it("COORDINATOR_11 - getContract() - Check that we get the REGISTRY address after two updateContracts", async function () {
         const reg = await Registry.new(this.test.coord.address);
         const reg2 = await Registry.new(this.test.coord.address);
 
-        await this.test.coord.updateContract('REGISTRY', reg.address);
-        await this.test.coord.updateContract('REGISTRY', reg2.address);
+        await this.test.coord.updateContract('REGISTRY', reg.address).should.be.fulfilled;
+        await this.test.coord.updateContract('REGISTRY', reg2.address).should.be.fulfilled;
 
-        await expect(await this.test.coord.getContract.call('REGISTRY')).equals(reg2.address);
+        let addr = await this.test.coord.getContract.call('REGISTRY');
+        addr.should.equal(reg2.address);
     });
 });

--- a/test/0_coordinator_test.js
+++ b/test/0_coordinator_test.js
@@ -15,8 +15,6 @@ const CurrentCost = artifacts.require("CurrentCost");
 const Utils = require("./helpers/utils.js");
 
 contract('ZapCoordinator', async (accounts) => {
-    const owner = accounts[0];
-
     beforeEach(async function deployContracts() {
         // Deploy initial contracts
         this.currentTest.coord = await ZapCoordinator.new();

--- a/test/1_registry_test.js
+++ b/test/1_registry_test.js
@@ -39,7 +39,6 @@ contract('Registry', async (accounts) => {
     beforeEach(async function deployContracts() {
         // Deploy initial contracts
         this.currentTest.coord = await ZapCoordinator.new();
-        const owner = await this.currentTest.coord.owner();
         this.currentTest.db = await Database.new();
         await this.currentTest.db.transferOwnership(this.currentTest.coord.address);
         await this.currentTest.coord.addImmutableContract('DATABASE', this.currentTest.db.address);
@@ -55,7 +54,7 @@ contract('Registry', async (accounts) => {
     });
 
     it("REGISTRY_1 - initiateProvider() - Check that we can initiate provider", async function () {
-        await this.test.registry.initiateProvider(publicKey, title, {from: owner });
+        await this.test.registry.initiateProvider(publicKey, title, { from: owner });
     });
 
     it("REGISTRY_2 - initiateProvider() - Check that we can't change provider info if it was initated", async function () {
@@ -94,8 +93,8 @@ contract('Registry', async (accounts) => {
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
         const val_a = web3utils.padLeft(web3utils.asciiToHex("World"), 64);
         const val_b = web3utils.padLeft(web3utils.asciiToHex("Orange"), 64);
-        await this.test.registry.setProviderParameter("Hello", val_a, {from: owner});
-        await this.test.registry.setProviderParameter("Apple", val_b, {from: owner});
+        await this.test.registry.setProviderParameter("Hello", val_a, { from: owner });
+        await this.test.registry.setProviderParameter("Apple", val_b, { from: owner });
 
         const a = await this.test.registry.getProviderParameter(owner, "Hello");
         const b = await this.test.registry.getProviderParameter(owner, "Apple");
@@ -131,7 +130,7 @@ contract('Registry', async (accounts) => {
     });
 
     it("REGISTRY_12 - getProviderCurve() - Check that we initialize and get provider curve", async function () {
-        await this.test.registry.initiateProvider(publicKey, title, {from: owner });
+        await this.test.registry.initiateProvider(publicKey, title, { from: owner });
         await this.test.registry.initiateProviderCurve(specifier, curve, emptyBroker, { from: owner });
         const x = await this.test.registry.getProviderCurve(owner, specifier);
 
@@ -172,7 +171,7 @@ contract('Registry', async (accounts) => {
     it("REGISTRY_16 - getEndpointBroker() - Check that broker address can be saved and retreived", async function () {
 
         let testBroker = owner;
-        await this.test.registry.initiateProvider(publicKey, title, {from: owner });
+        await this.test.registry.initiateProvider(publicKey, title, { from: owner });
         await this.test.registry.initiateProviderCurve(specifier, curve, testBroker, { from: owner });
         const savedBroker = await this.test.registry.getEndpointBroker(owner, specifier);
         console.log('broker: ', savedBroker);
@@ -183,22 +182,22 @@ contract('Registry', async (accounts) => {
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
         await this.test.registry.initiateProviderCurve(specifier, curve, emptyBroker, { from: owner });
 
-        let endpoints0 = await this.test.registry.getProviderEndpoints(owner, {from:owner});
+        let endpoints0 = await this.test.registry.getProviderEndpoints(owner, { from: owner });
 
-        await this.test.registry.clearEndpoint(specifier, {from: owner});
+        await this.test.registry.clearEndpoint(specifier, { from: owner });
 
-        let endpoints1 = await this.test.registry.getProviderEndpoints(owner, {from:owner});
+        let endpoints1 = await this.test.registry.getProviderEndpoints(owner, { from: owner });
         expect(endpoints0[0] != endpoints1[0]);
     });
 
     it("REGISTRY_18 -setProviderTitle() - Check that provider can change their title", async function () {
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
 
-        let title0 = await this.test.registry.getProviderTitle(owner, {from: owner});
+        let title0 = await this.test.registry.getProviderTitle(owner, { from: owner });
 
-        await this.test.registry.setProviderTitle('testRandom2341143', {from: owner});
+        await this.test.registry.setProviderTitle('testRandom2341143', { from: ownerj});
 
-        let title1 = await this.test.registry.getProviderTitle(owner, {from: owner});
+        let title1 = await this.test.registry.getProviderTitle(owner, { from: owner });
 
         console.log(title0, title1);
     });

--- a/test/1_registry_test.js
+++ b/test/1_registry_test.js
@@ -14,7 +14,7 @@ const CurrentCost = artifacts.require("CurrentCost");
 
 const Utils = require("./helpers/utils.js");
 
-function hex2a(hexx) { 
+function hex2a(hexx) {
     let hex = hexx.toString(); //force conversion
     let str = '';
     for (let i = 2; i < hex.length; i += 2) {
@@ -73,7 +73,6 @@ contract('Registry', async (accounts) => {
 
     it("REGISTRY_4 - initiateProviderCurve() - Check that we can't initiate provider curve if provider wasn't initiated", async function () {
         await expect(this.test.registry.initiateProviderCurve(specifier, curve, emptyBroker, { from: owner })).to.eventually.be.rejectedWith(EVMRevert);
-    });
 
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
 
@@ -150,7 +149,6 @@ contract('Registry', async (accounts) => {
         await expect(this.test.registry.getProviderCurve.call(owner, specifier, { from: owner })).to.be.eventually.rejectedWith(EVMRevert);
     });
 
-
     it("REGISTRY_14 - setProviderParameter()/setEndpointParams() - Check that a non-owner cannot edit provider & endpoint parameters", async function () {
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
         await this.test.registry.initiateProviderCurve(specifier, curve, emptyBroker, { from: owner });
@@ -177,10 +175,9 @@ contract('Registry', async (accounts) => {
         await this.test.registry.initiateProvider(publicKey, title, {from: owner });
         await this.test.registry.initiateProviderCurve(specifier, curve, testBroker, { from: owner });
         const savedBroker = await this.test.registry.getEndpointBroker(owner, specifier);
-        console.log('broker: ', savedBroker); 
+        console.log('broker: ', savedBroker);
         expect(savedBroker).to.be.equal(testBroker);
     });
-
 
     it("REGISTRY_17 -clearEndpoint() - Check that provider can clear endpoint with no bonds", async function () {
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
@@ -192,24 +189,17 @@ contract('Registry', async (accounts) => {
 
         let endpoints1 = await this.test.registry.getProviderEndpoints(owner, {from:owner});
         expect(endpoints0[0] != endpoints1[0]);
-    
     });
-
 
     it("REGISTRY_18 -setProviderTitle() - Check that provider can change their title", async function () {
-
         await this.test.registry.initiateProvider(publicKey, title, { from: owner });
-   
-        let title0 = await this.test.registry.getProviderTitle(owner, {from: owner}); 
-        
+
+        let title0 = await this.test.registry.getProviderTitle(owner, {from: owner});
+
         await this.test.registry.setProviderTitle('testRandom2341143', {from: owner});
 
-        let title1 = await this.test.registry.getProviderTitle(owner, {from: owner}); 
+        let title1 = await this.test.registry.getProviderTitle(owner, {from: owner});
 
-        console.log(title0, title1); 
-
+        console.log(title0, title1);
     });
-
-
-
 });

--- a/test/2_bondage_test.js
+++ b/test/2_bondage_test.js
@@ -30,7 +30,7 @@ contract('Bondage', function (accounts) {
 
     const specifier = "test-specifier";
     const zeroAddress = Utils.ZeroAddress;
-    
+
     const piecewiseFunction = [3, 0, 0, 2, 10000];
     const broker = 0;
 
@@ -74,7 +74,7 @@ contract('Bondage', function (accounts) {
 
         // Hack for making arbiter an account we control for testing the escrow
         await this.currentTest.coord.addImmutableContract('ARBITER', accounts[3]);
-        
+
         await this.currentTest.coord.updateAllDependencies({ from: owner });
     });
 
@@ -121,7 +121,6 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_6 - calcZapForDots() - Check that function revert if curve not intialized", async function () {
-
         //prepareProvider.call(this.test, true, false);
         await this.test.registry.initiateProvider(publicKey, title, { from: oracle });
         await expect(this.test.bondage.calcZapForDots.call(oracle, specifier, 5)).to.be.eventually.rejectedWith(EVMRevert);
@@ -152,7 +151,6 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_8 - getBoundDots() - Check received dots getting", async function () {
-
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
@@ -246,10 +244,10 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_14 - escrowDots() - Check that operator can't escrow dots from oracle that haven't got enough dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         /// we will get 0 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 0, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 0, { from: subscriber });
 
         const dots = 0;
         const dotsForEscrow = 2;
@@ -261,10 +259,10 @@ contract('Bondage', function (accounts) {
 
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
 
         const dots = 3;
         const dotsForEscrow = 2;
@@ -292,10 +290,10 @@ contract('Bondage', function (accounts) {
 
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
 
         const dots = 3;
         const dotsForEscrow = 2;
@@ -310,12 +308,12 @@ contract('Bondage', function (accounts) {
 
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
         // get another dot
-        await this.test.bondage.bond(oracle, specifier, 1, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 1, { from: subscriber });
 
         const issuedDots = await this.test.bondage.getDotsIssued.call(oracle, specifier);
         await expect(parseInt(issuedDots.valueOf())).to.be.equal(4);
@@ -325,14 +323,14 @@ contract('Bondage', function (accounts) {
 
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
         // and another to get 4 dots total
-        await this.test.bondage.bond(oracle, specifier, 1, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 1, { from: subscriber });
 
-        await this.test.bondage.unbond(oracle, specifier, 1, {from: subscriber});
+        await this.test.bondage.unbond(oracle, specifier, 1, { from: subscriber });
 
         const issuedDots = await this.test.bondage.getDotsIssued.call(oracle, specifier);
         await expect(parseInt(issuedDots.valueOf())).to.be.equal(3);
@@ -342,26 +340,26 @@ contract('Bondage', function (accounts) {
 
          await prepareProvider.call(this.test);
          await prepareTokens.call(this.test);
-         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+         await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
-         await expect(this.test.bondage.bond(oracle, specifier, approveTokens, {from: subscriber})).to.be.eventually.be.rejectedWith(EVMRevert);
+         await expect(this.test.bondage.bond(oracle, specifier, approveTokens, { from: subscriber })).to.be.eventually.be.rejectedWith(EVMRevert);
     });
 
     it("BONDAGE_20 - delegateBond() - Check that delegate bond can be executed", async function () {
-        await prepareProvider.call(this.test);      
+        await prepareProvider.call(this.test);
         await prepareTokens.call(this.test, accounts[4]);
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: accounts[4]});
 
-        await this.test.bondage.delegateBond(subscriber, oracle, specifier, dotBound, {from: accounts[4]});
+        await this.test.bondage.delegateBond(subscriber, oracle, specifier, dotBound, { from: accounts[4] });
     });
 
     it("BONDAGE_21 - returnDots() - Check that dots can be returned", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber}); 
+        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
 
         const dots = 3;
         const dotsForEscrow = 2;
@@ -383,7 +381,7 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_22 - returnDots() - Check that more dots can't be returned than already escrowed", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber}); 
+        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -399,10 +397,10 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_23 - returnDots() - Check that more dots can't be called by someone who isn't the owner", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber}); 
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
-        await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
 
         const dots = 3;
         const dotsForEscrow = 2;
@@ -416,7 +414,7 @@ contract('Bondage', function (accounts) {
 
 
         await this.test.token.allocate(oracle, tokensForOwner, { from: owner });
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: oracle});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: oracle });
 
         let testBroker = oracle;
         await this.test.registry.initiateProvider(publicKey, title, { from: oracle });
@@ -425,42 +423,38 @@ contract('Bondage', function (accounts) {
         let savedBroker = await this.test.registry.getEndpointBroker(oracle, specifier, { from: oracle });
 
         // with current linear curve (startValue = 1, multiplier = 2) number of dots received should be equal to 5
-        await this.test.bondage.bond(oracle, specifier, 3, {from: oracle});
+        await this.test.bondage.bond(oracle, specifier, 3, { from: oracle });
 
         const res = await this.test.bondage.getZapBound.call(oracle, specifier, { from: oracle });
         const receivedTok = parseInt(res.valueOf());
 
         await expect(receivedTok).to.be.equal(28);
-
     });
 
 
     it("BONDAGE_25 - bond() - Check that nonbroker cannot bond to broker endpoint", async function () {
 
         await this.test.token.allocate(subscriber, tokensForOwner, { from: owner });
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         await this.test.registry.initiateProvider(publicKey, title, { from: oracle });
         await this.test.registry.initiateProviderCurve(specifier, piecewiseFunction, oracle, { from: oracle });
 
         let savedBroker = await this.test.registry.getEndpointBroker(oracle, specifier, { from: subscriber });
 
-        await expect(this.test.bondage.bond(oracle, specifier, 3, {from: subscriber})).to.be.eventually.be.rejectedWith(EVMRevert);
+        await expect(this.test.bondage.bond(oracle, specifier, 3, { from: subscriber })).to.be.eventually.be.rejectedWith(EVMRevert);
     });
 
     it("BONDAGE_26 - bond() - Check registry.clearEndpoint cannot be applied to a bonded curve", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
 
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
-        await this.test.bondage.bond(oracle, specifier, dotBound, {from: subscriber});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
+        await this.test.bondage.bond(oracle, specifier, dotBound, { from: subscriber });
 
-        await expect(this.test.registry.clearEndpoint( specifier, {from: oracle})).to.eventually.be.rejectedWith(EVMRevert);
+        await expect(this.test.registry.clearEndpoint( specifier, { from: oracle })).to.eventually.be.rejectedWith(EVMRevert);
     });
-
-
-
-}); 
+});
 
 
 contract('CurrentCost', function (accounts) {
@@ -523,7 +517,7 @@ contract('CurrentCost', function (accounts) {
         // Deploy current cost
         this.currentTest.cost = await Cost.new(this.currentTest.coord.address);
         await this.currentTest.coord.updateContract('CURRENT_COST', this.currentTest.cost.address);
-        
+
         await this.currentTest.coord.updateAllDependencies({ from: owner });
     });
 

--- a/test/3_arbiter_test.js
+++ b/test/3_arbiter_test.js
@@ -32,7 +32,7 @@ contract('Arbiter', function (accounts) {
 
     // test function: 2x^2
     const piecewiseFunction = [3, 0, 0, 2, 10000];
-    
+
     const tokensForOwner = new BigNumber("1500e18");
     const tokensForSubscriber = new BigNumber("5000e18");
     const approveTokens = new BigNumber("1000e18");
@@ -195,7 +195,7 @@ contract('Arbiter', function (accounts) {
 
         await expect(this.test.arbiter.endSubscriptionProvider(subscriber, specifier, {from: accounts[7]})).to.eventually.be.rejectedWith(EVMRevert);
     });
-    
+
     it("ARBITER_10 - endSubscriptionProvider() - Check that subscriber receives any unused dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
@@ -213,7 +213,7 @@ contract('Arbiter', function (accounts) {
         await expect(parseInt(res[0].valueOf())).to.be.equal(10);
 
         const bondageEvents = this.test.bondage.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        bondageEvents.watch((err, res) => { }); 
+        bondageEvents.watch((err, res) => { });
 
         var mine = function() {
             return new Promise((resolve, reject) => {

--- a/test/4_dispatch_test.js
+++ b/test/4_dispatch_test.js
@@ -122,7 +122,7 @@ contract('Dispatch', function (accounts) {
         // Deploy Dispatch contract
         this.currentTest.dispatch = await Dispatch.new(this.currentTest.coord.address);
         await this.currentTest.coord.updateContract('DISPATCH', this.currentTest.dispatch.address);
-        
+
         await this.currentTest.coord.updateAllDependencies();
 
         this.currentTest.subscriber = await Subscriber.new(
@@ -139,14 +139,14 @@ contract('Dispatch', function (accounts) {
         await prepareTokens.call(this.test, subscriber);
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         // watch events
         const dispatchEvents = this.test.dispatch.allEvents({ fromBlock: 0, toBlock: 'latest' });
         dispatchEvents.watch((err, res) => { });
         const subscriberEvents = this.test.subscriber.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        subscriberEvents.watch((err, res) => {}); 
-        
+        subscriberEvents.watch((err, res) => {});
+
         // holder: subAddr (holder of dots)
         // subscriber: owner of zap
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
@@ -155,7 +155,7 @@ contract('Dispatch', function (accounts) {
         // SUBSCRIBE SUBSCRIBER TO RECIVE DATA FROM PROVIDER
         await this.test.subscriber.testQuery(oracleAddr, query, spec1, params);
 
-        // GET ALL EVENTS LOG 
+        // GET ALL EVENTS LOG
         const logs = await subscriberEvents.get();
         await expect(isEventReceived(logs, "Result1")).to.be.equal(true);
 
@@ -163,7 +163,7 @@ contract('Dispatch', function (accounts) {
         const result = logs[0].args["response1"];
         await expect(result).to.be.equal("Hello World");
 
-        // STOP WATCHING EVENTS 
+        // STOP WATCHING EVENTS
         dispatchEvents.stopWatching();
         subscriberEvents.stopWatching();
     });
@@ -181,20 +181,20 @@ contract('Dispatch', function (accounts) {
         await prepareTokens.call(this.test, subscriber);
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec1, 1, {from: subscriber});
 
         await expect(this.test.dispatch.query(oracleAddr, query, spec1, params, {from: accounts[4]})).to.be.eventually.rejectedWith(EVMRevert);
-    }); 
+    });
 
 
     it("DISPATCH_4 - query() - Check that our contract will revert with an invalid endpoint", async function () {
         await prepareTokens.call(this.test, subscriber);
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec1, 1, {from: subscriber});
@@ -207,10 +207,10 @@ contract('Dispatch', function (accounts) {
         await prepareTokens.call(this.test, subscriber);
 
         const subscriberEvents = this.test.subscriber.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        subscriberEvents.watch((err, res) => { }); 
+        subscriberEvents.watch((err, res) => { });
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         // Bond to endpoints 1-3
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
@@ -235,10 +235,10 @@ contract('Dispatch', function (accounts) {
     });
 
     it("DISPATCH_6 - Check that dispatch will revert if subscriber is subscribed to a different endpoint", async function () {
-        await prepareTokens.call(this.test, subscriber);    
+        await prepareTokens.call(this.test, subscriber);
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec1, 100, {from: subscriber});
@@ -248,18 +248,18 @@ contract('Dispatch', function (accounts) {
 
 
     it("DISPATCH_7 - query() - Check that the test oracle can access the given endpoint parameters and use respondBytes32Array", async function () {
-        await prepareTokens.call(this.test, subscriber);    
+        await prepareTokens.call(this.test, subscriber);
 
         const subscriberEvents = this.test.subscriber.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        subscriberEvents.watch((err, res) => { }); 
+        subscriberEvents.watch((err, res) => { });
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec3, 100, {from: subscriber});
 
-        let params3 = [toHex(1), toHex(2), toHex(3)]; 
+        let params3 = [toHex(1), toHex(2), toHex(3)];
 
         await this.test.subscriber.testQuery(oracleAddr, query, spec3, params3);
 
@@ -272,13 +272,13 @@ contract('Dispatch', function (accounts) {
     });
 
     it("DISPATCH_8 - Dispatch will revert if query has already been fulfilled", async function () {
-        await prepareTokens.call(this.test, subscriber);    
+        await prepareTokens.call(this.test, subscriber);
 
         const subscriberEvents = this.test.subscriber.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        subscriberEvents.watch((err, res) => { }); 
+        subscriberEvents.watch((err, res) => { });
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec1, 100, {from: subscriber});
@@ -296,17 +296,16 @@ contract('Dispatch', function (accounts) {
     });
 
     it("DISPATCH_9 - respond2() - Check that we can receive two return values", async function () {
-        await prepareTokens.call(this.test, subscriber);    
+        await prepareTokens.call(this.test, subscriber);
 
         const subscriberEvents = this.test.subscriber.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        subscriberEvents.watch((err, res) => { }); 
+        subscriberEvents.watch((err, res) => { });
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec4, 100, {from: subscriber});
-
         await this.test.subscriber.testQuery(oracleAddr, query, spec4, params);
 
         let logs = await subscriberEvents.get();
@@ -327,18 +326,18 @@ contract('Dispatch', function (accounts) {
     it("DISPATCH_10 - cancelQuery() - Check that a subscriber can cancel a query", async function () {
         // make a "bad" oracle (will never respond)
         this.test.oracle = await Oracle.new(this.test.registry.address, true);
-        
-        await prepareTokens.call(this.test, subscriber);    
+
+        await prepareTokens.call(this.test, subscriber);
 
         const subscriberEvents = this.test.subscriber.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        subscriberEvents.watch((err, res) => { }); 
+        subscriberEvents.watch((err, res) => { });
 
         const dispatchEvents = this.test.dispatch.allEvents({ fromBlock: 0, toBlock: 'latest' });
-        dispatchEvents.watch((err, res) => { }); 
+        dispatchEvents.watch((err, res) => { });
 
 
         var oracleAddr = this.test.oracle.address;
-        var subAddr = this.test.subscriber.address; 
+        var subAddr = this.test.subscriber.address;
 
         await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.delegateBond(subAddr, oracleAddr, spec4, 100, {from: subscriber});
@@ -349,7 +348,7 @@ contract('Dispatch', function (accounts) {
         var s_logs = await subscriberEvents.get();
         var queryId = s_logs[0].args["id"];
         var postQueryDots = await this.test.bondage.getBoundDots(this.test.subscriber.address, oracleAddr, spec4);
-        
+
         // expect to have escrowed a dot
         expect(dotBalance.minus(postQueryDots).toString()).to.be.equal("1");
 
@@ -357,19 +356,17 @@ contract('Dispatch', function (accounts) {
 
         let d_logs = await dispatchEvents.get();
         var newBalance = await this.test.bondage.getBoundDots(this.test.subscriber.address, oracleAddr, spec4);
-        
+
         expect(d_logs[0].event).to.be.equal("CanceledRequest");
         // expect escrowed dot to be returned
         expect(dotBalance.toString()).to.be.equal(newBalance.toString());
     });
-
-    
 
     // converts an integer to its 32-bit hex representation
     function toHex(num){
         var hex = web3.toHex(num).substring(2);
           while (hex.length < 64) hex = "0" + hex;
         hex = "0x" + hex;
-        return hex; 
+        return hex;
     }
-}); 
+});


### PR DESCRIPTION
I want to

1) ensure positive test cases are properly checked
2) avoid nested `await`s, which I find confusing
3) avoid the use of `expect` & `eventually` which I think are superfluous when in an async func using `await`

example cleanup of test: https://github.com/zapproject/zap-ethereum-api/commit/d0916632caba9daf8718a6bb50e48169ff8f39ce

fixing confusing test: owner redefined as identical value, shadowed in smaller scope https://github.com/zapproject/zap-ethereum-api/pull/91/commits/22f0104fe83f42d2ab111e74ae994b9dccba1d6d

the other commits are purely cosmetic.