### PR TITLE
Testing 4

### DIFF
--- a/contracts/lib/platform/ERCDotFactory.sol
+++ b/contracts/lib/platform/ERCDotFactory.sol
@@ -32,11 +32,10 @@ contract ERCDotFactory is Ownable {
         bytes32 symbol,
         int256[] curve
     ) returns(address) {
-
         require(curves[specifier] == 0, "Curve specifier already exists");
 
         RegistryInterface registry = RegistryInterface(coord.getContract("REGISTRY"));
-        if(!registry.isProviderInitiated(address(this))) {
+        if (!registry.isProviderInitiated(address(this))) {
             registry.initiateProvider(providerPubKey, providerTitle);
         }
 
@@ -73,7 +72,6 @@ contract ERCDotFactory is Ownable {
         tokenAddress = address(token);
         return tokenAddress;
     }
-
 
     //https://ethereum.stackexchange.com/questions/2519/how-to-convert-a-bytes32-to-string
     function bytes32ToString(bytes32 x) constant returns (string) {

--- a/contracts/platform/bondage/Bondage.sol
+++ b/contracts/platform/bondage/Bondage.sol
@@ -297,9 +297,9 @@ contract Bondage is Destructible, BondageInterface, Upgradable {
     function updateEscrow(address holderAddress, address oracleAddress, bytes32 endpoint, uint256 numDots, bytes32 op) internal {
         uint256 newEscrow = db.getNumber(keccak256(abi.encodePacked('escrow', holderAddress, oracleAddress, endpoint)));
 
-        if ( op == "sub" ) {
+        if (op == "sub") {
             newEscrow -= numDots;
-        } else if ( op == "add" ) {
+        } else if (op == "add") {
             newEscrow += numDots;
         }
         else {

--- a/contracts/platform/dispatch/Dispatch.sol
+++ b/contracts/platform/dispatch/Dispatch.sol
@@ -121,14 +121,14 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
         uint256 dots = bondage.getBoundDots(msg.sender, provider, endpoint);
         bool onchainProvider = isContract(provider);
         bool onchainSubscriber = isContract(msg.sender);
-        if(dots >= 1) {
+        if (dots >= 1) {
             //enough dots
             bondage.escrowDots(msg.sender, provider, endpoint, 1);
 
             id = uint256(keccak256(abi.encodePacked(block.number, now, userQuery, msg.sender, provider)));
 
             createQuery(id, provider, msg.sender, endpoint, userQuery, onchainSubscriber);
-            if(onchainProvider) {
+            if (onchainProvider) {
                 OnChainProvider(provider).receive(id, userQuery, endpoint, endpointParams, onchainSubscriber);
             } else{
                 emit Incoming(id, provider, msg.sender, userQuery, endpoint, endpointParams, onchainSubscriber);
@@ -149,7 +149,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
         address provider = getProvider(id);
         bytes32 endpoint = getEndpoint(id);
 
-        if ( status == Status.Canceled ) {
+        if (status == Status.Canceled) {
             uint256 canceled = getCancel(id);
 
             // Make sure we've canceled in the past,
@@ -205,7 +205,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
     {
         if (getProvider(id) != msg.sender || !fulfillQuery(id))
             revert();
-        if(getSubscriberOnchain(id)) {
+        if (getSubscriberOnchain(id)) {
             ClientBytes32Array(getSubscriber(id)).callback(id, response);
         }
         else {
@@ -224,7 +224,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
     {
         if (getProvider(id) != msg.sender || !fulfillQuery(id))
             revert();
-        if(getSubscriberOnchain(id)) {
+        if (getSubscriberOnchain(id)) {
             ClientIntArray(getSubscriber(id)).callback(id, response);
         }
         else {
@@ -245,7 +245,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
         if (getProvider(id) != msg.sender || !fulfillQuery(id))
             revert();
 
-        if(getSubscriberOnchain(id)) {
+        if (getSubscriberOnchain(id)) {
             Client1(getSubscriber(id)).callback(id, response);
         }
         else {
@@ -266,7 +266,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
         if (getProvider(id) != msg.sender || !fulfillQuery(id))
             revert();
 
-        if(getSubscriberOnchain(id)) {
+        if (getSubscriberOnchain(id)) {
             Client2(getSubscriber(id)).callback(id, response1, response2);
         }
         else {
@@ -289,7 +289,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
         if (getProvider(id) != msg.sender || !fulfillQuery(id))
             revert();
 
-        if(getSubscriberOnchain(id)) {
+        if (getSubscriberOnchain(id)) {
             Client3(getSubscriber(id)).callback(id, response1, response2, response3);
         }
         else {
@@ -313,7 +313,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
         if (getProvider(id) != msg.sender || !fulfillQuery(id))
             revert();
 
-        if(getSubscriberOnchain(id)) {
+        if (getSubscriberOnchain(id)) {
             Client4(getSubscriber(id)).callback(id, response1, response2, response3, response4);
         }
         else {
@@ -392,7 +392,7 @@ contract Dispatch is Destructible, DispatchInterface, Upgradable {
     }
 
     function setCanceled(uint256 id, bool canceled) private {
-        if ( canceled ) {
+        if (canceled) {
             db.setNumber(keccak256(abi.encodePacked('queries', id, 'cancelBlock')), block.number);
             db.setNumber(keccak256(abi.encodePacked('queries', id, 'status')), uint256(Status.Canceled));
         }

--- a/test/2_bondage_test.js
+++ b/test/2_bondage_test.js
@@ -82,7 +82,6 @@ contract('Bondage', function (accounts) {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
 
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, dotBound, {from: subscriber});
     });
 
@@ -127,7 +126,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_7 - unbond() - Check unbond zap for dots calculation", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         let balance = await this.test.token.balanceOf(subscriber);
         // we will get 5 dots with current curve (n: [1-5], p = 2n^2)
@@ -147,7 +145,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_7_big - unbond() - Check unbond zap for dots calculation", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         let balance = await this.test.token.balanceOf(subscriber);
 
@@ -172,7 +169,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_8 - getBoundDots() - Check received dots getting", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // with current linear curve (startValue = 1, multiplier = 2) number of dots received should be equal to 5
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -184,7 +180,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_9 - getBoundDots() - Check that number of dots of unbonded provider is 0", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         const res = await this.test.bondage.getBoundDots.call(subscriber, oracle, specifier, { from: subscriber });
         res.should.be.bignumber.equal(web3.toBigNumber(0));
@@ -194,7 +189,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_10 - getZapBound() - Check received ZAP getting", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // with current linear curve (startValue = 1, multiplier = 2) number of dots received should be equal to 5
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -206,7 +200,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_11 - getZapBound() - Check that received ZAP of unbonded provider is 0", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         const res = await this.test.bondage.getZapBound.call(oracle, specifier, { from: subscriber });
         res.should.be.bignumber.equal(web3.toBigNumber(0));
@@ -215,7 +208,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_12 - escrowDots() - Check that operator can escrow dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -235,7 +227,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_13 - escrowDots() - Check that not operator can't escrow dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -249,7 +240,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_14 - escrowDots() - Check that operator can't escrow dots from oracle that haven't got enough dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         /// we will get 0 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 0, { from: subscriber });
@@ -263,7 +253,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_15 - releaseDots() - Check that operator can release dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -287,10 +276,8 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_16 - releaseDots() - Check that operator can't release dots if trying to release more dots than escrowed", async function () {
-
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
@@ -305,10 +292,8 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_17 - getDotsIssued() - Check that issued dots will increase with every bond", async function () {
-
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
@@ -320,10 +305,8 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_18 - getDotsIssued() - Check that issued dots will decrease with every unbond", async function () {
-
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
@@ -337,26 +320,23 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_19 - bond() - Check bond function", async function () {
-
          await prepareProvider.call(this.test);
          await prepareTokens.call(this.test);
-         await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
-         await expect(this.test.bondage.bond(oracle, specifier, approveTokens, { from: subscriber })).to.be.eventually.be.rejectedWith(EVMRevert);
+         await expect(this.test.bondage.bond(oracle, specifier, approveTokens, {from: subscriber})).to.be.eventually.be.rejectedWith(EVMRevert);
     });
 
     it("BONDAGE_20 - delegateBond() - Check that delegate bond can be executed", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test, accounts[4]);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: accounts[4]});
 
-        await this.test.bondage.delegateBond(subscriber, oracle, specifier, dotBound, { from: accounts[4] });
+        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: accounts[4]});
+        await this.test.bondage.delegateBond(subscriber, oracle, specifier, dotBound, {from: accounts[4]});
     });
 
     it("BONDAGE_21 - returnDots() - Check that dots can be returned", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -378,7 +358,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_22 - returnDots() - Check that more dots can't be returned than already escrowed", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, {from: subscriber});
@@ -394,7 +373,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_23 - returnDots() - Check that more dots can't be called by someone who isn't the owner", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         // we will get 3 dots with current curve
         await this.test.bondage.bond(oracle, specifier, 3, { from: subscriber });
@@ -408,16 +386,14 @@ contract('Bondage', function (accounts) {
     });
 
     it("BONDAGE_24 - bond() - Check that broker can bond to its endpoint", async function () {
-
-
-        await this.test.token.allocate(oracle, tokensForOwner, { from: owner });
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: oracle });
+        await this.test.token.allocate(oracle, tokensForOwner, {from: owner});
+        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: oracle});
 
         let testBroker = oracle;
-        await this.test.registry.initiateProvider(publicKey, title, { from: oracle });
-        await this.test.registry.initiateProviderCurve(specifier, piecewiseFunction, testBroker, { from: oracle });
+        await this.test.registry.initiateProvider(publicKey, title, {from: oracle});
+        await this.test.registry.initiateProviderCurve(specifier, piecewiseFunction, testBroker, {from: oracle});
 
-        let savedBroker = await this.test.registry.getEndpointBroker(oracle, specifier, { from: oracle });
+        let savedBroker = await this.test.registry.getEndpointBroker(oracle, specifier, {from: oracle});
 
         // with current linear curve (startValue = 1, multiplier = 2) number of dots received should be equal to 5
         await this.test.bondage.bond(oracle, specifier, 3, { from: oracle });
@@ -430,7 +406,6 @@ contract('Bondage', function (accounts) {
     it("BONDAGE_25 - bond() - Check that nonbroker cannot bond to broker endpoint", async function () {
 
         await this.test.token.allocate(subscriber, tokensForOwner, { from: owner });
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
 
         await this.test.registry.initiateProvider(publicKey, title, { from: oracle });
         await this.test.registry.initiateProviderCurve(specifier, piecewiseFunction, oracle, { from: oracle });
@@ -444,7 +419,6 @@ contract('Bondage', function (accounts) {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
 
-        await this.test.token.approve(this.test.bondage.address, approveTokens, { from: subscriber });
         await this.test.bondage.bond(oracle, specifier, dotBound, { from: subscriber });
 
         await expect(this.test.registry.clearEndpoint( specifier, { from: oracle })).to.eventually.be.rejectedWith(EVMRevert);
@@ -491,7 +465,6 @@ contract('CurrentCost', function (accounts) {
     async function prepareTokens(allocAddress = subscriber) {
         await this.token.allocate(owner, tokensForOwner, { from: owner });
         await this.token.allocate(allocAddress, tokensForSubscriber, { from: owner });
-        //await this.token.approve(this.bondage.address, approveTokens, {from: subscriber});
     }
 
     beforeEach(async function deployContracts() {

--- a/test/3_arbiter_test.js
+++ b/test/3_arbiter_test.js
@@ -39,13 +39,13 @@ contract('Arbiter', function (accounts) {
 
     async function prepareProvider() {
         await this.registry.initiateProvider(publicKey, title, { from: oracle });
-        await this.registry.initiateProviderCurve(specifier, piecewiseFunction, Utils.ZeroAddress, { from: oracle });
+        await this.registry.initiateProviderCurve(specifier, piecewiseFunction, Utils.ZeroAddress, {from: oracle});
     }
 
     async function prepareTokens() {
-        await this.token.allocate(owner, tokensForOwner, { from: owner });
-        await this.token.allocate(subscriber, tokensForSubscriber, { from: owner });
-        //await this.token.approve(this.bondage.address, approveTokens, {from: subscriber});
+        await this.token.allocate(owner, tokensForOwner, {from: owner});
+        await this.token.allocate(subscriber, tokensForSubscriber, {from: owner});
+        await this.token.approve(this.bondage.address, approveTokens, {from: subscriber});
     }
 
     beforeEach(async function deployContracts() {
@@ -78,7 +78,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_1 - initiateSubscription() - Check subscription", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
@@ -91,7 +90,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_2 - initiateSubscription() - Check subscription block must be more than 0", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
 
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
@@ -101,7 +99,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_3 - initiateSubscription() - Check user can inititate subscription for same subscriber once", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         await this.test.arbiter.initiateSubscription(oracle, specifier, params, publicKey, 10, {from: subscriber});
@@ -115,7 +112,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_4 - endSubscriptionProvider() - Check ending subscription", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         await this.test.arbiter.initiateSubscription(oracle, specifier, params, publicKey, 10, {from: subscriber});
@@ -132,7 +128,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_5 - endSubscriptionProvider() - Check that user can't end uninitialized subscription", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         //await this.test.arbiter.initiateSubscription(oracle, params, specifier, publicKey, 10, {from: subscriber});
@@ -143,7 +138,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_6 - endSubscriptionSubscriber() - Check ending subscription", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         await this.test.arbiter.initiateSubscription(oracle, specifier, params, publicKey, 10, {from: subscriber});
@@ -160,7 +154,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_7 - endSubscriptionSubscriber() - Check that user can't end uninitialized subscription", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         //await this.test.arbiter.initiateSubscription(oracle, params, specifier, publicKey, 10, {from: subscriber});
@@ -171,7 +164,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_8 - endSubscriptionSubscriber() - Check that only subscriber can end subscription by subscriber", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         await this.test.arbiter.initiateSubscription(oracle, specifier, params, publicKey, 10, {from: subscriber});
@@ -185,7 +177,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_9 - endSubscriptionProvider() - Check that only provider can end subscription by provider", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 1000, {from: subscriber});
 
         await this.test.arbiter.initiateSubscription(oracle, specifier, params, publicKey, 10, {from: subscriber});
@@ -199,7 +190,6 @@ contract('Arbiter', function (accounts) {
     it("ARBITER_10 - endSubscriptionProvider() - Check that subscriber receives any unused dots", async function () {
         await prepareProvider.call(this.test);
         await prepareTokens.call(this.test);
-        await this.test.token.approve(this.test.bondage.address, approveTokens, {from: subscriber});
         await this.test.bondage.bond(oracle, specifier, 100, {from: subscriber});
 
         let initBalance = await this.test.bondage.getBoundDots(subscriber, oracle, specifier);

--- a/test/4_dispatch_test.js
+++ b/test/4_dispatch_test.js
@@ -95,7 +95,6 @@ contract('Dispatch', function (accounts) {
     async function prepareTokens(allocAddress = subscriber) {
         await this.token.allocate(owner, tokensForOwner, { from: owner });
         await this.token.allocate(allocAddress, tokensForSubscriber, { from: owner });
-        //await this.token.approve(this.bondage.address, approveTokens, {from: subscriber});
     }
 
     beforeEach(async function deployContracts() {
@@ -350,7 +349,7 @@ contract('Dispatch', function (accounts) {
         var postQueryDots = await this.test.bondage.getBoundDots(this.test.subscriber.address, oracleAddr, spec4);
 
         // expect to have escrowed a dot
-        expect(dotBalance.minus(postQueryDots).toString()).to.be.equal("1");
+        dotBalance.minus(postQueryDots).should.be.bignumber.equal(web3.toBigNumber(1));
 
         await this.test.subscriber.cancelQuery(queryId);
 
@@ -359,7 +358,7 @@ contract('Dispatch', function (accounts) {
 
         expect(d_logs[0].event).to.be.equal("CanceledRequest");
         // expect escrowed dot to be returned
-        expect(dotBalance.toString()).to.be.equal(newBalance.toString());
+        dotBalance.should.be.bignumber.equal(newBalance);
     });
 
     // converts an integer to its 32-bit hex representation


### PR DESCRIPTION
# Notes & comments

## `Bondage.sol`
- `releaseDots`, `returnDots`, `escrowDots` all needlessly return `bool success`. They only ever return `true` or throw an error upon failure. Either the error should be changed to `return false` or the `return true` should be removed.

## `Database.sol`
```
- Roy Blankman, [Jan 20, 2019, 19:23:22]:
... when you update a contract like Bondage.sol, do you want the data to be available at the same `key`s as before?

If you make a simple update, you're hashing the same path to get a key, keccak256(abi.encodePacked('holders', holderAddress, 'oracleList')), so you'll have to make sure the new version of the contract is compatible with the existing data. otherwise, you can prefix all keys with the contract address in Database.sol if you want to silo every contract data and make overwrites impossible--but this would only be a good idea if you don't want to persist data across updated contracts.

overwriting data isn't a problem if you're careful about choosing keys in the contracts registered with ZapCoordinator.sol, but it would be nice to eliminate the concern entirely.
```